### PR TITLE
Fixes #34332

### DIFF
--- a/scripts/cocoapods/flipper.rb
+++ b/scripts/cocoapods/flipper.rb
@@ -83,7 +83,7 @@ def flipper_post_install(installer)
         # Enable flipper for React-Core Debug configuration
         if target.name == 'React-Core'
             target.build_configurations.each do |config|
-                if config.name == 'Debug'
+                if config.debug?
                     config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] = ['$(inherited)', 'FB_SONARKIT_ENABLED=1']
                 end
             end


### PR DESCRIPTION
Fixed Flipper not recognizing app when using custom Xcode configuration names.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This fixes the problem that renaming the "Debug" Xcode configuration causes Flipper to not work. Despite using the recommended `:configurations` parameters and instructing Cocoapods that it was a debug build (see #34332), it still wouldn't recognize the app due to missing C preprocessor flags, specifically it was missing `-DFB_SONARKIT_ENABLED=1`.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

General Fixed - Flipper now supports custom Xcode build configuration names

## Test Plan

I applied the PR change to 0.68.2 (which work similarly but code was refactored since then). I then used `patch-package` to test the change and the fix worked on 2 separate projects.
Patch-package change equivalent:
```diff
diff --git a/node_modules/react-native/scripts/react_native_pods.rb b/node_modules/react-native/scripts/react_native_pods.rb
index f2ceeda..2ea57d6 100644
--- a/node_modules/react-native/scripts/react_native_pods.rb
+++ b/node_modules/react-native/scripts/react_native_pods.rb
@@ -180,7 +180,7 @@ def flipper_post_install(installer)
     # Enable flipper for React-Core Debug configuration
     if target.name == 'React-Core'
       target.build_configurations.each do |config|
-        if config.name == 'Debug'
+        if config.debug?
           config.build_settings['OTHER_CFLAGS'] = "$(inherited) -DFB_SONARKIT_ENABLED=1"
         end
       end
```



